### PR TITLE
Mainpage get other user schedule

### DIFF
--- a/src/main/java/hsu/bee/petra/common/configuration/JpaAuditingConfiguration.java
+++ b/src/main/java/hsu/bee/petra/common/configuration/JpaAuditingConfiguration.java
@@ -2,8 +2,10 @@ package hsu.bee.petra.common.configuration;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
 @EnableJpaAuditing
+@EnableScheduling
 public class JpaAuditingConfiguration {
 }

--- a/src/main/java/hsu/bee/petra/common/configuration/WebConfiguration.java
+++ b/src/main/java/hsu/bee/petra/common/configuration/WebConfiguration.java
@@ -27,6 +27,7 @@ public class WebConfiguration implements WebMvcConfigurer {
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(authenticationInterceptor)
 			.excludePathPatterns("/")
+				.excludePathPatterns("/mainpage/**")
 			.excludePathPatterns("/api/**")
 			.excludePathPatterns("/login")
 			.excludePathPatterns("/schedule/");

--- a/src/main/java/hsu/bee/petra/location/entity/Sigungu.java
+++ b/src/main/java/hsu/bee/petra/location/entity/Sigungu.java
@@ -7,12 +7,16 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.MapsId;
 
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor
+@EqualsAndHashCode
 public class Sigungu {
 
 	@EmbeddedId

--- a/src/main/java/hsu/bee/petra/location/entity/SigunguId.java
+++ b/src/main/java/hsu/bee/petra/location/entity/SigunguId.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Embeddable
 @NoArgsConstructor
+@AllArgsConstructor
 @EqualsAndHashCode
 public class SigunguId implements Serializable {
 

--- a/src/main/java/hsu/bee/petra/location/repository/AreaRepository.java
+++ b/src/main/java/hsu/bee/petra/location/repository/AreaRepository.java
@@ -1,0 +1,11 @@
+package hsu.bee.petra.location.repository;
+
+import hsu.bee.petra.location.entity.Area;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AreaRepository extends JpaRepository<Area, Integer> {
+
+    public List<Area> findByIdIn(List<Integer> areaId);
+}

--- a/src/main/java/hsu/bee/petra/location/repository/SigunguRepository.java
+++ b/src/main/java/hsu/bee/petra/location/repository/SigunguRepository.java
@@ -1,0 +1,12 @@
+package hsu.bee.petra.location.repository;
+
+import hsu.bee.petra.location.entity.Sigungu;
+import hsu.bee.petra.location.entity.SigunguId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SigunguRepository extends JpaRepository<Sigungu, SigunguId> {
+
+    public List<Sigungu> findByIdIn(List<SigunguId> sigunguIdList);
+}

--- a/src/main/java/hsu/bee/petra/mainpage/controller/MainPageController.java
+++ b/src/main/java/hsu/bee/petra/mainpage/controller/MainPageController.java
@@ -6,9 +6,8 @@ import hsu.bee.petra.response.ResponseMessage;
 import hsu.bee.petra.schedule.dto.OtherUserScheduleDto;
 import hsu.bee.petra.schedule.service.ScheduleService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
@@ -20,38 +19,41 @@ public class MainPageController {
     private final ScheduleService scheduleService;
 
     @GetMapping("/mainpage/famous-schedules")
-    public Response getFamousSchedules() {
+    public Response getFamousSchedules(@RequestParam(value="page", required=false, defaultValue= "0") Integer page) {
 
-        ArrayList<OtherUserScheduleDto> result = scheduleService.getFamousSchedule();
+        int size = 10;
+
+        ArrayList<OtherUserScheduleDto> result = scheduleService.getFamousSchedules(size, page);
 
         return new Response(ResponseCode.SUCCESS, ResponseMessage.SUCCESS, result);
     }
 
     @GetMapping("/mainpage/newest-schedules")
-    public Response getNewestSchedules() {
+    public Response getNewestSchedules(@RequestParam(value="page", required=false, defaultValue= "0") Integer page) {
 
-        // 0페이지 10개 가져오기
-        PageRequest pageRequest = PageRequest
-                .of(0, 10)
-                .withSort(Sort.Direction.DESC, "createdAt");
-        ArrayList<OtherUserScheduleDto> result = scheduleService.getNewestSchedule(pageRequest);
+        int size = 10;
+
+        ArrayList<OtherUserScheduleDto> result = scheduleService.getNewestSchedules(size, page);
 
         return new Response(ResponseCode.SUCCESS, ResponseMessage.SUCCESS, result);
     }
 
     @GetMapping("/mainpage/long-period-schedules")
-    public Response getLongestPeriodSchedules() {
+    public Response getLongestPeriodSchedules(@RequestParam(value="page", required=false, defaultValue= "0") Integer page) {
 
-        ArrayList<OtherUserScheduleDto> result = scheduleService.getLongestTimeSchedule();
+        int size = 10;
+
+        ArrayList<OtherUserScheduleDto> result = scheduleService.getLongestPeriodSchedules(size, page);
 
         return new Response(ResponseCode.SUCCESS, ResponseMessage.SUCCESS, result);
     }
 
     @GetMapping("/mainpage/long-distance-schedules")
-    public Response getLongestDistanceSchedules() {
-        int page = 0;
+    public Response getLongestDistanceSchedules(@RequestParam(value="page", required=false, defaultValue= "0") Integer page) {
+
         int size = 10;
-        ArrayList<OtherUserScheduleDto> result = scheduleService.getLongestDistanceSchedule(size, page);
+
+        ArrayList<OtherUserScheduleDto> result = scheduleService.getLongestDistanceSchedules(size, page);
 
         return new Response(ResponseCode.SUCCESS, ResponseMessage.SUCCESS, result);
     }

--- a/src/main/java/hsu/bee/petra/mainpage/controller/MainPageController.java
+++ b/src/main/java/hsu/bee/petra/mainpage/controller/MainPageController.java
@@ -1,0 +1,58 @@
+package hsu.bee.petra.mainpage.controller;
+
+import hsu.bee.petra.response.Response;
+import hsu.bee.petra.response.ResponseCode;
+import hsu.bee.petra.response.ResponseMessage;
+import hsu.bee.petra.schedule.dto.OtherUserScheduleDto;
+import hsu.bee.petra.schedule.service.ScheduleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+
+@RestController
+@RequiredArgsConstructor
+public class MainPageController {
+
+    private final ScheduleService scheduleService;
+
+    @GetMapping("/mainpage/famous-schedules")
+    public Response getFamousSchedules() {
+
+        ArrayList<OtherUserScheduleDto> result = scheduleService.getFamousSchedule();
+
+        return new Response(ResponseCode.SUCCESS, ResponseMessage.SUCCESS, result);
+    }
+
+    @GetMapping("/mainpage/newest-schedules")
+    public Response getNewestSchedules() {
+
+        // 0페이지 10개 가져오기
+        PageRequest pageRequest = PageRequest
+                .of(0, 10)
+                .withSort(Sort.Direction.DESC, "createdAt");
+        ArrayList<OtherUserScheduleDto> result = scheduleService.getNewestSchedule(pageRequest);
+
+        return new Response(ResponseCode.SUCCESS, ResponseMessage.SUCCESS, result);
+    }
+
+    @GetMapping("/mainpage/long-period-schedules")
+    public Response getLongestPeriodSchedules() {
+
+        ArrayList<OtherUserScheduleDto> result = scheduleService.getLongestTimeSchedule();
+
+        return new Response(ResponseCode.SUCCESS, ResponseMessage.SUCCESS, result);
+    }
+
+    @GetMapping("/mainpage/long-distance-schedules")
+    public Response getLongestDistanceSchedules() {
+        int page = 0;
+        int size = 10;
+        ArrayList<OtherUserScheduleDto> result = scheduleService.getLongestDistanceSchedule(size, page);
+
+        return new Response(ResponseCode.SUCCESS, ResponseMessage.SUCCESS, result);
+    }
+}

--- a/src/main/java/hsu/bee/petra/schedule/dto/OtherUserScheduleDto.java
+++ b/src/main/java/hsu/bee/petra/schedule/dto/OtherUserScheduleDto.java
@@ -2,6 +2,7 @@ package hsu.bee.petra.schedule.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import hsu.bee.petra.code.entity.TravelCode;
+import hsu.bee.petra.location.entity.Sigungu;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -16,7 +17,7 @@ public class OtherUserScheduleDto {
 
     private Long scheduleId;
 
-    private TravelCode travelCode;
+    private String travelCodeName;
 
     private Double totalDistance;
 
@@ -28,4 +29,5 @@ public class OtherUserScheduleDto {
 
     private Long travelPeriod;
 
+    private Sigungu sigungu;
 }

--- a/src/main/java/hsu/bee/petra/schedule/dto/OtherUserScheduleDto.java
+++ b/src/main/java/hsu/bee/petra/schedule/dto/OtherUserScheduleDto.java
@@ -1,0 +1,31 @@
+package hsu.bee.petra.schedule.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import hsu.bee.petra.code.entity.TravelCode;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class OtherUserScheduleDto {
+
+    private Long scheduleId;
+
+    private TravelCode travelCode;
+
+    private Double totalDistance;
+
+    private Long views;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private Long travelPeriod;
+
+}

--- a/src/main/java/hsu/bee/petra/schedule/dto/SchedulePlanXYDto.java
+++ b/src/main/java/hsu/bee/petra/schedule/dto/SchedulePlanXYDto.java
@@ -1,0 +1,24 @@
+package hsu.bee.petra.schedule.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SchedulePlanXYDto {
+
+    Long scheduleId;
+    Long planId;
+    Integer planOrder;
+    String x;
+    String y;
+
+    public SchedulePlanXYDto(Long scheduleId) {
+        this.scheduleId = scheduleId;
+    }
+
+}

--- a/src/main/java/hsu/bee/petra/schedule/dto/ScheduleSigunguDto.java
+++ b/src/main/java/hsu/bee/petra/schedule/dto/ScheduleSigunguDto.java
@@ -1,0 +1,8 @@
+package hsu.bee.petra.schedule.dto;
+
+public interface ScheduleSigunguDto {
+    long getScheduleId();
+    int getSigungu();
+    int getArea();
+    int getCount();
+}

--- a/src/main/java/hsu/bee/petra/schedule/dto/TravelTypeDto.java
+++ b/src/main/java/hsu/bee/petra/schedule/dto/TravelTypeDto.java
@@ -1,0 +1,8 @@
+package hsu.bee.petra.schedule.dto;
+
+public interface TravelTypeDto {
+
+    long getScheduleId();
+    String getTravelCodeName();
+
+}

--- a/src/main/java/hsu/bee/petra/schedule/entity/Schedule.java
+++ b/src/main/java/hsu/bee/petra/schedule/entity/Schedule.java
@@ -39,6 +39,7 @@ public class Schedule extends Timestamp {
 	private String title;
 	private int adult;
 	private int child;
+	private long views;
 	private LocalDate startDate;
 	private LocalDate endDate;
 

--- a/src/main/java/hsu/bee/petra/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/hsu/bee/petra/schedule/repository/ScheduleRepository.java
@@ -1,5 +1,6 @@
 package hsu.bee.petra.schedule.repository;
 
+import hsu.bee.petra.schedule.dto.ScheduleSigunguDto;
 import hsu.bee.petra.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -36,6 +37,11 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             "FROM attraction att JOIN address ad ON (att.address_id = ad.id) ) aa\n" +
             "ON ( aa.attraction_id = scp.attraction_id )\n" +
             "ORDER BY scp.scheduleId, scp.planOrder", nativeQuery = true)
-    List<Tuple> findXY(@Param("scheduleIdList") ArrayList<Long> scheduleIdList);
+    List<Tuple> findXY(@Param("scheduleIdList") List<Long> scheduleIdList);
 
+    @Query(value="select s.id as scheduleId, a.sigungu_id as sigungu, a.area_id as area, count(*) as count\n" +
+            "FROM Plan p, Schedule s, Attraction a\n" +
+            "WHERE s.id IN :scheduleList AND p.schedule_id = s.id and p.attraction_id = a.id and s.id\n" +
+            "group by s.id, a.sigungu_id, a.area_Id;", nativeQuery = true)
+    List<ScheduleSigunguDto> getSigunguFromSchedule(@Param(value="scheduleList")List<Long> scheduleIdList);
 }

--- a/src/main/java/hsu/bee/petra/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/hsu/bee/petra/schedule/repository/ScheduleRepository.java
@@ -1,13 +1,41 @@
 package hsu.bee.petra.schedule.repository;
 
 import hsu.bee.petra.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import hsu.bee.petra.schedule.entity.Schedule;
+
+import javax.persistence.Tuple;
+import java.util.ArrayList;
+import java.util.List;
 
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     Long countByUser(User user);
+
+    @Query(value="Select * FROM ( SELECT * FROM Schedule ORDER BY created_at DESC LIMIT :limit) s ORDER BY s.views DESC LIMIT :size ", nativeQuery = true)
+    ArrayList<Schedule> getFamousSchedule(@Param(value="limit")int limit, @Param(value="size")int size);
+
+    ArrayList<Schedule> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    @Query(value = "SELECT * FROM ( SELECT * FROM Schedule s ORDER BY created_at desc LIMIT :limit) s ORDER BY TIMESTAMPDIFF(DAY, s.start_date, s.end_date) DESC LIMIT :size", nativeQuery = true)
+    ArrayList<Schedule> getSchedulesUsingTimediff(@Param(value="limit")int value, @Param(value= "size")int size);
+
+    @Query(value="SELECT scp.scheduleId, scp.planId, scp.planOrder, aa.x, aa.y \n" +
+            "FROM \n" +
+            "( SELECT s.id scheduleId, p.id planId, p.attraction_id as attraction_id, p.order as planOrder\n" +
+            "FROM schedule s JOIN Plan p ON ( s.id = p.schedule_id )\n" +
+            "WHERE s.id IN :scheduleIdList ) scp \n" +
+            "JOIN\n" +
+            "( SELECT ad.x as x, ad.y as y, att.id as attraction_id\n" +
+            "FROM attraction att JOIN address ad ON (att.address_id = ad.id) ) aa\n" +
+            "ON ( aa.attraction_id = scp.attraction_id )\n" +
+            "ORDER BY scp.scheduleId, scp.planOrder", nativeQuery = true)
+    List<Tuple> findXY(@Param("scheduleIdList") ArrayList<Long> scheduleIdList);
+
 }

--- a/src/main/java/hsu/bee/petra/schedule/repository/TravelTypeRepository.java
+++ b/src/main/java/hsu/bee/petra/schedule/repository/TravelTypeRepository.java
@@ -1,13 +1,22 @@
 package hsu.bee.petra.schedule.repository;
 
+import hsu.bee.petra.schedule.dto.TravelTypeDto;
 import hsu.bee.petra.schedule.entity.Schedule;
 import hsu.bee.petra.schedule.entity.TravelType;
 import hsu.bee.petra.schedule.entity.TravelTypeId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TravelTypeRepository extends JpaRepository<TravelType, TravelTypeId> {
 
     Optional<TravelType> findBySchedule(Schedule schedule);
+
+    @Query(value="select tt.schedule_id as scheduleId, tc.code as travelCodeName\n" +
+            "from travel_code tc, travel_type tt\n" +
+            "where tt.code_id = tc.id and tt.schedule_id in :scheduleList", nativeQuery = true)
+    List<TravelTypeDto> findTravelTypeBySchedule(@Param("scheduleList") List<Long> scheduleList);
 }

--- a/src/main/java/hsu/bee/petra/schedule/repository/TravelTypeRepository.java
+++ b/src/main/java/hsu/bee/petra/schedule/repository/TravelTypeRepository.java
@@ -1,0 +1,13 @@
+package hsu.bee.petra.schedule.repository;
+
+import hsu.bee.petra.schedule.entity.Schedule;
+import hsu.bee.petra.schedule.entity.TravelType;
+import hsu.bee.petra.schedule.entity.TravelTypeId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TravelTypeRepository extends JpaRepository<TravelType, TravelTypeId> {
+
+    Optional<TravelType> findBySchedule(Schedule schedule);
+}

--- a/src/main/java/hsu/bee/petra/schedule/service/ScheduleService.java
+++ b/src/main/java/hsu/bee/petra/schedule/service/ScheduleService.java
@@ -5,6 +5,11 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import hsu.bee.petra.location.entity.Area;
+import hsu.bee.petra.location.entity.Sigungu;
+import hsu.bee.petra.location.entity.SigunguId;
+import hsu.bee.petra.location.repository.AreaRepository;
+import hsu.bee.petra.location.repository.SigunguRepository;
 import hsu.bee.petra.schedule.dto.*;
 import hsu.bee.petra.schedule.entity.TravelType;
 import hsu.bee.petra.schedule.repository.TravelTypeRepository;
@@ -29,6 +34,7 @@ import hsu.bee.petra.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.annotation.PostConstruct;
 import javax.persistence.Tuple;
 
 @Slf4j
@@ -36,17 +42,30 @@ import javax.persistence.Tuple;
 @RequiredArgsConstructor
 public class ScheduleService {
 
-	private final UserRepository userRepository;
 	private final AttractionRepository attractionRepository;
 	private final ScheduleRepository scheduleRepository;
 	private final PlanRepository planRepository;
 	private final StatusRepository statusRepository;
 	private final TravelTypeRepository travelTypeRepository;
-	private static ArrayList<OtherUserScheduleDto> longDistanceScheduleDtoList = new ArrayList<>();
+	private final AreaRepository areaRepository;
+	private final SigunguRepository sigunguRepository;
+
+	private static ArrayList<OtherUserScheduleDto> newestOtherUserScheduleDtos = new ArrayList<>();
+	private static ArrayList<OtherUserScheduleDto> famousOtherUserScheduleDtos = new ArrayList<>();
+	private static ArrayList<OtherUserScheduleDto> longDistanceOtherUserScheduleDtos = new ArrayList<>();
+	private static ArrayList<OtherUserScheduleDto> longPeriodOtherUserScheduleDtos = new ArrayList<>();
 
 	public List<ScheduleDto> recommendSchedules(AnswerDto answerDto, User user) {
 		List<ScheduleDto> schedulesRecommended = new ArrayList<>();
 		return schedulesRecommended;
+	}
+
+	@PostConstruct
+	public void postConstruct() {
+		updateNewestSchedules();
+		updateFamousSchedules();
+		updateLongestPeriodSchedule();
+		updateLongestDistanceSchedule();
 	}
 
 	@Transactional
@@ -94,90 +113,206 @@ public class ScheduleService {
 		return planDtoList;
 	}
 
-    public ArrayList<OtherUserScheduleDto> getFamousSchedule() {
+	public ArrayList<OtherUserScheduleDto> getNewestSchedules(int size, int page) {
 
-		int range = 1000;
-		int size = 10;
-		ArrayList<Schedule> scheduleList = scheduleRepository.getFamousSchedule(range, size);
+		ArrayList<OtherUserScheduleDto> pagedSchedules = new ArrayList<>();
 
-		ArrayList<OtherUserScheduleDto> result = new ArrayList<>();
-		for (Schedule schedule : scheduleList) {
-			OtherUserScheduleDto temp =
+		if(newestOtherUserScheduleDtos.size() < size*page) {
+
+		} else if(newestOtherUserScheduleDtos.size() < (page+1) * size) {
+			for (int i = size * page; i < newestOtherUserScheduleDtos.size(); i++) {
+				pagedSchedules.add(newestOtherUserScheduleDtos.get(i));
+			}
+		} else {
+			for (int i = size * page; i < (page + 1) * size; i++) {
+				pagedSchedules.add(newestOtherUserScheduleDtos.get(i));
+			}
+		}
+		return pagedSchedules;
+	}
+
+	// 매 1시간마다 최신순 스케줄 리스트 최신화
+	@Scheduled(cron="0 0 0/1 1/1 * ?")
+	public void updateNewestSchedules() {
+
+		int page = 0, size = 100;
+
+		PageRequest pageRequest = PageRequest
+				.of(page, size)
+				.withSort(Sort.Direction.DESC, "createdAt");
+
+		ArrayList<Schedule> schedules = scheduleRepository.findAllByOrderByCreatedAtDesc(pageRequest);
+		ArrayList<Long> scheduleIds = new ArrayList<>();
+
+		for(Schedule schedule : schedules) {
+			scheduleIds.add(schedule.getId());
+		}
+
+		HashMap<Long, Double> calcedTotalDistances = calculateTotalDistance(scheduleIds);
+		HashMap<Long, Sigungu> calcedRepresenatativeArea = calculateRepresentativeArea(scheduleIds);
+		HashMap<Long, Long> calcedTotalDate = calculateTotalDate(schedules);
+		HashMap<Long, String> schedulesTravelCode = getTravelCodeFromSchedule(scheduleIds);
+
+		newestOtherUserScheduleDtos.clear();
+
+		for(Schedule schedule : schedules ) {
+
+			long id = schedule.getId();
+			newestOtherUserScheduleDtos.add(
 					OtherUserScheduleDto.builder()
-							.scheduleId(schedule.getId())
+							.scheduleId(id)
+							.travelCodeName(schedulesTravelCode.get(id))
+							.totalDistance(calcedTotalDistances.get(id))
 							.views(schedule.getViews())
 							.startDate(schedule.getStartDate())
 							.endDate(schedule.getEndDate())
-							.travelPeriod(ChronoUnit.DAYS.between(schedule.getStartDate(), schedule.getEndDate()))
-							.build();
+							.travelPeriod(calcedTotalDate.get(id))
+							.sigungu(calcedRepresenatativeArea.get(id))
+							.build()
+			);
+		}
+	}
 
-			TravelType travelCode = travelTypeRepository.findBySchedule(schedule).orElseThrow(() -> new IllegalArgumentException("해당 스케줄의 TravelCode가 존재하지 않습니다."));
-			temp.setTravelCode(travelCode.getTravelCode());
-			result.add(temp);
+	public ArrayList<OtherUserScheduleDto> getFamousSchedules(int size, int page) {
+
+		ArrayList<OtherUserScheduleDto> pagedSchedules = new ArrayList<>();
+
+		if(famousOtherUserScheduleDtos.size() < size*page) {
+
+		} else if(famousOtherUserScheduleDtos.size() < (page+1) * size) {
+			for (int i = size * page; i < famousOtherUserScheduleDtos.size(); i++) {
+				pagedSchedules.add(famousOtherUserScheduleDtos.get(i));
+			}
+		} else {
+			for (int i = size * page; i < (page + 1) * size; i++) {
+				pagedSchedules.add(famousOtherUserScheduleDtos.get(i));
+			}
 		}
 
-		return result;
-    }
+		return pagedSchedules;
+	}
 
-	public ArrayList<OtherUserScheduleDto> getNewestSchedule(Pageable pageable) {
+	//매 1시간마다 최다뷰 스케줄 리스트 최신화
+	@Scheduled(cron="0 0 0/1 1/1 * ?")
+	public void updateFamousSchedules() {
 
-		ArrayList<OtherUserScheduleDto> result = new ArrayList<>();
-		ArrayList<Schedule> scheduleList = scheduleRepository.findAllByOrderByCreatedAtDesc(pageable);
+		// 최근 1000개 중 가장 많이 조회된 100개 Repo에서 가져오기
+		int choices = 1000, size = 100;
 
-		for (Schedule schedule : scheduleList) {
-			OtherUserScheduleDto temp =
+		ArrayList<Schedule> schedules = scheduleRepository.getFamousSchedule(choices, size);
+		ArrayList<Long> scheduleIds = new ArrayList<>();
+//		schedules.stream().map(schedule -> scheduleIds.add(schedule.getId()));
+
+		for(Schedule schedule : schedules) {
+			scheduleIds.add(schedule.getId());
+		}
+
+		HashMap<Long, Double> calcedTotalDistances = calculateTotalDistance(scheduleIds);
+		HashMap<Long, Sigungu> calcedRepresenatativeArea = calculateRepresentativeArea(scheduleIds);
+		HashMap<Long, Long> calcedTotalDate = calculateTotalDate(schedules);
+		HashMap<Long, String> schedulesTravelCode = getTravelCodeFromSchedule(scheduleIds);
+
+		famousOtherUserScheduleDtos.clear();
+
+		for(Schedule schedule : schedules ) {
+
+			long id = schedule.getId();
+			famousOtherUserScheduleDtos.add(
 					OtherUserScheduleDto.builder()
-							.scheduleId(schedule.getId())
+							.scheduleId(id)
+							.travelCodeName(schedulesTravelCode.get(id))
+							.totalDistance(calcedTotalDistances.get(id))
 							.views(schedule.getViews())
 							.startDate(schedule.getStartDate())
 							.endDate(schedule.getEndDate())
-							.travelPeriod(ChronoUnit.DAYS.between(schedule.getStartDate(), schedule.getEndDate()))
-							.build();
-
-			TravelType travelCode = travelTypeRepository.findBySchedule(schedule).orElseThrow(() -> new IllegalArgumentException("해당 스케줄의 TravelCode가 존재하지 않습니다."));
-			temp.setTravelCode(travelCode.getTravelCode());
-			result.add(temp);
+							.travelPeriod(calcedTotalDate.get(id))
+							.sigungu(calcedRepresenatativeArea.get(id))
+							.build()
+			);
 		}
-
-		return result;
 	}
 
-	public ArrayList<OtherUserScheduleDto> getLongestTimeSchedule() {
+	public ArrayList<OtherUserScheduleDto> getLongestPeriodSchedules(int size, int page) {
 
-		int limit = 1000;
-		int size = 10;
-		ArrayList<OtherUserScheduleDto> result = new ArrayList<>();
-		ArrayList<Schedule> scheduleList = new ArrayList<>();
+		ArrayList<OtherUserScheduleDto> pagedSchedules = new ArrayList<>();
 
-		// 가장 최근생성된 limit개 에서 가장 여행 기간 긴 스케쥴을 몇 page의 몇 size만큼 가져오기
-		scheduleList = scheduleRepository.getSchedulesUsingTimediff(limit, size);
+		if(longPeriodOtherUserScheduleDtos.size() < size*page) {
 
-		for (Schedule schedule : scheduleList) {
-			OtherUserScheduleDto temp =
+		} else if(longPeriodOtherUserScheduleDtos.size() < (page+1) * size) {
+			for (int i = size * page; i < longPeriodOtherUserScheduleDtos.size(); i++) {
+				pagedSchedules.add(longPeriodOtherUserScheduleDtos.get(i));
+			}
+		} else {
+			for (int i = size * page; i < (page + 1) * size; i++) {
+				pagedSchedules.add(longPeriodOtherUserScheduleDtos.get(i));
+			}
+		}
+
+		return pagedSchedules;
+	}
+
+	// 매 1시간마다 최장 거리 리스트 최신화
+	@Scheduled(cron="0 0 0/1 1/1 * ?")
+	public void updateLongestPeriodSchedule() {
+
+		int choices = 1000;
+		int size = 100;
+
+		ArrayList<Schedule> schedules = scheduleRepository.getSchedulesUsingTimediff(choices, size);
+		ArrayList<Long> scheduleIds = new ArrayList<>();
+
+		for(Schedule schedule : schedules) {
+			scheduleIds.add(schedule.getId());
+		}
+
+		HashMap<Long, Double> calcedTotalDistances = calculateTotalDistance(scheduleIds);
+		HashMap<Long, Sigungu> calcedRepresenatativeArea = calculateRepresentativeArea(scheduleIds);
+		HashMap<Long, Long> calcedTotalDate = calculateTotalDate(schedules);
+		HashMap<Long, String> schedulesTravelCode = getTravelCodeFromSchedule(scheduleIds);
+
+		longPeriodOtherUserScheduleDtos.clear();
+
+		for(Schedule schedule : schedules ) {
+
+			long id = schedule.getId();
+			longPeriodOtherUserScheduleDtos.add(
 					OtherUserScheduleDto.builder()
-							.scheduleId(schedule.getId())
+							.scheduleId(id)
+							.travelCodeName(schedulesTravelCode.get(id))
+							.totalDistance(calcedTotalDistances.get(id))
 							.views(schedule.getViews())
 							.startDate(schedule.getStartDate())
 							.endDate(schedule.getEndDate())
-							.travelPeriod(ChronoUnit.DAYS.between(schedule.getStartDate(), schedule.getEndDate()))
-							.build();
-
-			TravelType travelCode = travelTypeRepository.findBySchedule(schedule).orElseThrow(() -> new IllegalArgumentException("해당 스케줄의 TravelCode가 존재하지 않습니다."));
-			temp.setTravelCode(travelCode.getTravelCode());
-			result.add(temp);
+							.travelPeriod(calcedTotalDate.get(id))
+							.sigungu(calcedRepresenatativeArea.get(id))
+							.build()
+			);
 		}
 
-		return result;
 	}
 
-	public ArrayList<OtherUserScheduleDto> getLongestDistanceSchedule(int size, int page) {
+	public ArrayList<OtherUserScheduleDto> getLongestDistanceSchedules(int size, int page) {
 
-		return longDistanceScheduleDtoList;
+		ArrayList<OtherUserScheduleDto> pagedSchedules = new ArrayList<>();
+
+		if(longDistanceOtherUserScheduleDtos.size() < size*page) {
+
+		} else if(longDistanceOtherUserScheduleDtos.size() < (page+1) * size) {
+			for (int i = size * page; i < longDistanceOtherUserScheduleDtos.size(); i++) {
+				pagedSchedules.add(longDistanceOtherUserScheduleDtos.get(i));
+			}
+		} else {
+			for (int i = size * page; i < (page + 1) * size; i++) {
+				pagedSchedules.add(longDistanceOtherUserScheduleDtos.get(i));
+			}
+		}
+
+		return pagedSchedules;
 	}
 
-	// 매 30분마다 최장 거리 리스트 최신화
-	@Scheduled(cron="0 0/3 * 1/1 * ?")
-	protected void updateLongDistanceSchedule() {
+	// 매 1시간마다 최장 거리 리스트 최신화
+	@Scheduled(cron="0 0 0/1 1/1 * ?")
+	public void updateLongestDistanceSchedule() {
 
 		// 최신순으로 1000개 뽑아서 그 중에서 추리기
 		int size = 1000;
@@ -185,15 +320,86 @@ public class ScheduleService {
 				.of(0, size)
 				.withSort(Sort.Direction.DESC, "createdAt");
 
-		Page<Schedule> scheduleList = scheduleRepository.findAll(pageRequest);
-//		ArrayList<Long> scheduleIdList = new ArrayList<>();
-		HashMap<Long, Schedule> scheduleIdList = new HashMap<>();
-		scheduleList.map((schedule) -> scheduleIdList.put(schedule.getId(), schedule));
+		List<Schedule> schedules = scheduleRepository.findAllByOrderByCreatedAtDesc(pageRequest);
+		HashMap<Long, Schedule> scheduleMap = new HashMap<>();
+//		schedules.stream().map(schedule -> scheduleIds.add(schedule.getId()));
+
+		for(Schedule schedule : schedules) {
+			scheduleMap.put(schedule.getId(), schedule);
+		}
+
+		ArrayList<Long> scheduleIds = new ArrayList<>(scheduleMap.keySet());
+
+		HashMap<Long, Double> calcedTotalDistances = calculateTotalDistance(scheduleIds);
+
+		ArrayList<Long> sortedList = new ArrayList<>();
+
+		// 1000개 중 100개 정렬
+		for (Map.Entry<Long, Double> entry : calcedTotalDistances.entrySet()) {
+
+			int num =0;
+			long scheduleId = entry.getKey();
+			double totalDistance = entry.getValue();
+
+			if(sortedList.isEmpty()) {
+				sortedList.add(scheduleId);
+				continue;
+			}
+
+			for(int i=0; i<sortedList.size() && i<100; i++) {
+
+				if(calcedTotalDistances.get(sortedList.get(i)) < totalDistance ) {
+					sortedList.add(i, scheduleId);
+					break;
+				}
+			}
+
+		}
+
+		for( Long l : sortedList) {
+			System.out.println("scheduleId : " + l + " totalDistance : " + calcedTotalDistances.get(l));
+		}
+
+//		schedules = scheduleRepository.findByIdIn(sortedList);
+		schedules.clear();
+
+		for(Long id : sortedList) {
+			schedules.add(scheduleMap.get(id));
+		}
+
+		HashMap<Long, Sigungu> calcedRepresenatativeArea = calculateRepresentativeArea(sortedList);
+		HashMap<Long, Long> calcedTotalDate = calculateTotalDate(schedules);
+		HashMap<Long, String> schedulesTravelCode = getTravelCodeFromSchedule(sortedList);
+
+		longDistanceOtherUserScheduleDtos.clear();
+
+		for(Schedule schedule : schedules ) {
+
+			long id = schedule.getId();
+			longDistanceOtherUserScheduleDtos.add(
+					OtherUserScheduleDto.builder()
+							.scheduleId(id)
+							.travelCodeName(schedulesTravelCode.get(id))
+							.totalDistance(calcedTotalDistances.get(id))
+							.views(schedule.getViews())
+							.startDate(schedule.getStartDate())
+							.endDate(schedule.getEndDate())
+							.travelPeriod(calcedTotalDate.get(id))
+							.sigungu(calcedRepresenatativeArea.get(id))
+							.build()
+			);
+		}
+
+		log.info("최신화");
+	}
+
+	// 스케줄 하나 당 총 여행거리 계산
+	private HashMap<Long, Double> calculateTotalDistance(List<Long> scheduleIds) {
 
 		// Schedule-Plan-Attraction-Address 전부 join해서 (ScheduleId, planId, planOrder, x, y) 전부 끌어오기
-		List<Tuple> tupleResult = scheduleRepository.findXY(new ArrayList<>(scheduleIdList.keySet()));
+		List<Tuple> tupleResult = scheduleRepository.findXY(scheduleIds);
 
-		List<SchedulePlanXYDto> schedulePlanXYDto = tupleResult.stream()
+		List<SchedulePlanXYDto> list = tupleResult.stream()
 				.map(t -> new SchedulePlanXYDto(
 						t.get(0, BigInteger.class).longValue(),
 						t.get(1, BigInteger.class).longValue(),
@@ -202,65 +408,101 @@ public class ScheduleService {
 						t.get(4, String.class)
 				)).collect(Collectors.toList());
 
-		// 100개의 <스케줄 id, 거리 총합> 저장
 		HashMap<Long, Double> totalDistance = new HashMap<>();
 
 		// 스케줄, planOrder 순으로 조회되었다고 가정
-		// Math.round(pie*100)/100.0
-		for(int i=0; i<schedulePlanXYDto.size()-1; i++) {
-			if(schedulePlanXYDto.get(i).getScheduleId() == schedulePlanXYDto.get(i+1).getScheduleId()) {
-				double x1 = Double.parseDouble(schedulePlanXYDto.get(i).getX());
-				double y1 = Double.parseDouble(schedulePlanXYDto.get(i).getY());
-				double x2 = Double.parseDouble(schedulePlanXYDto.get(i+1).getX());
-				double y2 = Double.parseDouble(schedulePlanXYDto.get(i+1).getY());
+		for(int i=0; i<list.size()-1; i++) {
+			if(list.get(i).getScheduleId() == list.get(i+1).getScheduleId()) {
+
+				double x1 = Double.parseDouble(list.get(i).getX());
+				double y1 = Double.parseDouble(list.get(i).getY());
+				double x2 = Double.parseDouble(list.get(i+1).getX());
+				double y2 = Double.parseDouble(list.get(i+1).getY());
+
 				long distance = (long) distance(x1,y1,x2,y2,"M");
-				System.out.println("scheduleId : " + schedulePlanXYDto.get(i).getScheduleId() + " | origin : " + schedulePlanXYDto.get(i+1).getPlanId() + " - " + schedulePlanXYDto.get(i).getPlanId());
-				System.out.println(schedulePlanXYDto.get(i).getPlanOrder() + " - " + schedulePlanXYDto.get(i+1).getPlanOrder() + "distance : " + distance);
-				totalDistance.put(schedulePlanXYDto.get(i).getScheduleId(), totalDistance.getOrDefault(schedulePlanXYDto.get(i).getScheduleId(), 0.0) + distance);
-			}
-
-		}
-
-		ArrayList<Long> sortedList = new ArrayList<>();
-
-		for (Map.Entry<Long, Double> entry : totalDistance.entrySet()) {
-			if(sortedList.isEmpty()) {
-				sortedList.add(entry.getKey());
-				continue;
-			}
-
-			int num =0;
-
-			while(entry.getValue() < totalDistance.get(sortedList.get(num)) && num < sortedList.size()) {
-				if(num > 10)
-					break;
-				num++;
-			}
-			if(num < 10) {
-				sortedList.add(num, entry.getKey());
+				System.out.println("scheduleId : " + list.get(i).getScheduleId() + " | origin : " + list.get(i+1).getPlanId() + " - " + list.get(i).getPlanId());
+				System.out.println(list.get(i).getPlanOrder() + " - " + list.get(i+1).getPlanOrder() + "distance : " + distance);
+				totalDistance.put(list.get(i).getScheduleId(), totalDistance.getOrDefault(list.get(i).getScheduleId(), 0.0) + distance);
 			}
 		}
-//		longDistanceSchedule.clear();
-		longDistanceScheduleDtoList.clear();
-		for (Long a : sortedList) {
-			Schedule s = scheduleIdList.get(a);
-			OtherUserScheduleDto ousd = OtherUserScheduleDto.builder()
-					.scheduleId(s.getId())
-					.totalDistance(totalDistance.get(s.getId())/(double)1000)
-					.startDate(s.getStartDate())
-					.endDate(s.getEndDate())
-					.views(s.getViews())
-					.build();
 
-			TravelType travelCode = travelTypeRepository.findBySchedule(s).orElseThrow(() -> new IllegalArgumentException("해당 스케줄의 TravelCode가 존재하지 않습니다."));
-			ousd.setTravelCode(travelCode.getTravelCode());
-			ousd.setTravelPeriod(ChronoUnit.DAYS.between(ousd.getStartDate(), ousd.getEndDate()));
-//			longDistanceSchedule.put(a, totalDistance.get(a));
-			longDistanceScheduleDtoList.add(ousd);
-			System.out.println("scheduleId : " + s.getId() + " : " + ousd.getScheduleId() + " distance : " + ousd.getTotalDistance());
+		return totalDistance;
+	}
+
+	// 스케줄의 대표지역 선정
+	private HashMap<Long, Sigungu> calculateRepresentativeArea(List<Long> scheduleIds) {
+
+		HashMap<Long, Sigungu> result = new HashMap<>();
+
+		List<ScheduleSigunguDto> scheduleList = scheduleRepository.getSigunguFromSchedule(scheduleIds);
+
+		HashMap<Long, ScheduleSigunguDto> maxCount = new HashMap<>();
+
+		for (ScheduleSigunguDto scheduleSigunguDto : scheduleList) {
+			if (maxCount.containsKey(scheduleSigunguDto.getScheduleId())) {
+				if (scheduleSigunguDto.getCount() > maxCount.get(scheduleSigunguDto.getScheduleId()).getCount()) {
+					maxCount.put(scheduleSigunguDto.getScheduleId(), scheduleSigunguDto);
+				}
+			} else {
+				maxCount.put(scheduleSigunguDto.getScheduleId(), scheduleSigunguDto);
+			}
+
+			HashSet<Integer> areaIdList = new HashSet<>();
+			HashSet<SigunguId> sigunguIdList = new HashSet<>();
+
+			for (ScheduleSigunguDto ssd : maxCount.values()) {
+				areaIdList.add(ssd.getArea());
+				sigunguIdList.add(new SigunguId(ssd.getSigungu(), ssd.getArea()));
+			}
+
+			List<Area> areaList = areaRepository.findByIdIn(new ArrayList<>(areaIdList));
+			List<Sigungu> sigunguList = sigunguRepository.findByIdIn(new ArrayList<>(sigunguIdList));
+
+			for (ScheduleSigunguDto ssd : maxCount.values()) {
+
+				Area a = null;
+				for (int i = 0; i < areaList.size(); i++) {
+					if (areaList.get(i).getId() == ssd.getArea()) {
+						a = areaList.get(i);
+						break;
+					}
+				}
+
+				SigunguId si = new SigunguId(ssd.getSigungu(), ssd.getArea());
+				for (int i = 0; i < sigunguList.size(); i++) {
+					if (sigunguList.get(i).getId().equals(si)) {
+						result.put(ssd.getScheduleId(), new Sigungu(si, a, sigunguList.get(i).getName()));
+						break;
+					}
+				}
+			}
 		}
 
-		log.info("최신화");
+		return result;
+	}
+
+	// 스케줄의 총 여행일 계산
+	private HashMap<Long, Long> calculateTotalDate(List<Schedule> schedules) {
+
+		HashMap<Long, Long> scheduleTotalDates = new HashMap<>();
+		for(Schedule schedule : schedules) {
+			scheduleTotalDates.put(schedule.getId(), ChronoUnit.DAYS.between(schedule.getStartDate(), schedule.getEndDate()));
+		}
+
+		return scheduleTotalDates;
+	}
+
+	// 스케줄의 여행 타입 가져오기
+	private HashMap<Long, String> getTravelCodeFromSchedule(List<Long> scheduleIds) {
+
+		HashMap<Long, String> result = new HashMap<>();
+
+		List<TravelTypeDto> TravelTypeList = travelTypeRepository.findTravelTypeBySchedule(scheduleIds);
+
+		for (TravelTypeDto travelTypeDto : TravelTypeList) {
+			result.put(travelTypeDto.getScheduleId(), travelTypeDto.getTravelCodeName());
+		}
+		return result;
 	}
 
 	// 출처 - https://www.geodatasource.com/developers/java

--- a/src/main/java/hsu/bee/petra/schedule/service/ScheduleService.java
+++ b/src/main/java/hsu/bee/petra/schedule/service/ScheduleService.java
@@ -1,9 +1,18 @@
 package hsu.bee.petra.schedule.service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.math.BigInteger;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.stream.Collectors;
 
+import hsu.bee.petra.schedule.dto.*;
+import hsu.bee.petra.schedule.entity.TravelType;
+import hsu.bee.petra.schedule.repository.TravelTypeRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,10 +20,6 @@ import hsu.bee.petra.attraction.entity.Attraction;
 import hsu.bee.petra.attraction.repository.AttractionRepository;
 import hsu.bee.petra.code.entity.Status;
 import hsu.bee.petra.code.repository.StatusRepository;
-import hsu.bee.petra.schedule.dto.AnswerDto;
-import hsu.bee.petra.schedule.dto.NewScheduleDto;
-import hsu.bee.petra.schedule.dto.PlanDto;
-import hsu.bee.petra.schedule.dto.ScheduleDto;
 import hsu.bee.petra.schedule.entity.Plan;
 import hsu.bee.petra.schedule.entity.Schedule;
 import hsu.bee.petra.schedule.repository.PlanRepository;
@@ -23,6 +28,8 @@ import hsu.bee.petra.user.entity.User;
 import hsu.bee.petra.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import javax.persistence.Tuple;
 
 @Slf4j
 @Service
@@ -34,6 +41,8 @@ public class ScheduleService {
 	private final ScheduleRepository scheduleRepository;
 	private final PlanRepository planRepository;
 	private final StatusRepository statusRepository;
+	private final TravelTypeRepository travelTypeRepository;
+	private static ArrayList<OtherUserScheduleDto> longDistanceScheduleDtoList = new ArrayList<>();
 
 	public List<ScheduleDto> recommendSchedules(AnswerDto answerDto, User user) {
 		List<ScheduleDto> schedulesRecommended = new ArrayList<>();
@@ -83,5 +92,196 @@ public class ScheduleService {
 			planDtoList.add(PlanDto.convertPlanDto(plan));
 		}
 		return planDtoList;
+	}
+
+    public ArrayList<OtherUserScheduleDto> getFamousSchedule() {
+
+		int range = 1000;
+		int size = 10;
+		ArrayList<Schedule> scheduleList = scheduleRepository.getFamousSchedule(range, size);
+
+		ArrayList<OtherUserScheduleDto> result = new ArrayList<>();
+		for (Schedule schedule : scheduleList) {
+			OtherUserScheduleDto temp =
+					OtherUserScheduleDto.builder()
+							.scheduleId(schedule.getId())
+							.views(schedule.getViews())
+							.startDate(schedule.getStartDate())
+							.endDate(schedule.getEndDate())
+							.travelPeriod(ChronoUnit.DAYS.between(schedule.getStartDate(), schedule.getEndDate()))
+							.build();
+
+			TravelType travelCode = travelTypeRepository.findBySchedule(schedule).orElseThrow(() -> new IllegalArgumentException("해당 스케줄의 TravelCode가 존재하지 않습니다."));
+			temp.setTravelCode(travelCode.getTravelCode());
+			result.add(temp);
+		}
+
+		return result;
+    }
+
+	public ArrayList<OtherUserScheduleDto> getNewestSchedule(Pageable pageable) {
+
+		ArrayList<OtherUserScheduleDto> result = new ArrayList<>();
+		ArrayList<Schedule> scheduleList = scheduleRepository.findAllByOrderByCreatedAtDesc(pageable);
+
+		for (Schedule schedule : scheduleList) {
+			OtherUserScheduleDto temp =
+					OtherUserScheduleDto.builder()
+							.scheduleId(schedule.getId())
+							.views(schedule.getViews())
+							.startDate(schedule.getStartDate())
+							.endDate(schedule.getEndDate())
+							.travelPeriod(ChronoUnit.DAYS.between(schedule.getStartDate(), schedule.getEndDate()))
+							.build();
+
+			TravelType travelCode = travelTypeRepository.findBySchedule(schedule).orElseThrow(() -> new IllegalArgumentException("해당 스케줄의 TravelCode가 존재하지 않습니다."));
+			temp.setTravelCode(travelCode.getTravelCode());
+			result.add(temp);
+		}
+
+		return result;
+	}
+
+	public ArrayList<OtherUserScheduleDto> getLongestTimeSchedule() {
+
+		int limit = 1000;
+		int size = 10;
+		ArrayList<OtherUserScheduleDto> result = new ArrayList<>();
+		ArrayList<Schedule> scheduleList = new ArrayList<>();
+
+		// 가장 최근생성된 limit개 에서 가장 여행 기간 긴 스케쥴을 몇 page의 몇 size만큼 가져오기
+		scheduleList = scheduleRepository.getSchedulesUsingTimediff(limit, size);
+
+		for (Schedule schedule : scheduleList) {
+			OtherUserScheduleDto temp =
+					OtherUserScheduleDto.builder()
+							.scheduleId(schedule.getId())
+							.views(schedule.getViews())
+							.startDate(schedule.getStartDate())
+							.endDate(schedule.getEndDate())
+							.travelPeriod(ChronoUnit.DAYS.between(schedule.getStartDate(), schedule.getEndDate()))
+							.build();
+
+			TravelType travelCode = travelTypeRepository.findBySchedule(schedule).orElseThrow(() -> new IllegalArgumentException("해당 스케줄의 TravelCode가 존재하지 않습니다."));
+			temp.setTravelCode(travelCode.getTravelCode());
+			result.add(temp);
+		}
+
+		return result;
+	}
+
+	public ArrayList<OtherUserScheduleDto> getLongestDistanceSchedule(int size, int page) {
+
+		return longDistanceScheduleDtoList;
+	}
+
+	// 매 30분마다 최장 거리 리스트 최신화
+	@Scheduled(cron="0 0/3 * 1/1 * ?")
+	protected void updateLongDistanceSchedule() {
+
+		// 최신순으로 1000개 뽑아서 그 중에서 추리기
+		int size = 1000;
+		PageRequest pageRequest = PageRequest
+				.of(0, size)
+				.withSort(Sort.Direction.DESC, "createdAt");
+
+		Page<Schedule> scheduleList = scheduleRepository.findAll(pageRequest);
+//		ArrayList<Long> scheduleIdList = new ArrayList<>();
+		HashMap<Long, Schedule> scheduleIdList = new HashMap<>();
+		scheduleList.map((schedule) -> scheduleIdList.put(schedule.getId(), schedule));
+
+		// Schedule-Plan-Attraction-Address 전부 join해서 (ScheduleId, planId, planOrder, x, y) 전부 끌어오기
+		List<Tuple> tupleResult = scheduleRepository.findXY(new ArrayList<>(scheduleIdList.keySet()));
+
+		List<SchedulePlanXYDto> schedulePlanXYDto = tupleResult.stream()
+				.map(t -> new SchedulePlanXYDto(
+						t.get(0, BigInteger.class).longValue(),
+						t.get(1, BigInteger.class).longValue(),
+						t.get(2, Integer.class),
+						t.get(3, String.class),
+						t.get(4, String.class)
+				)).collect(Collectors.toList());
+
+		// 100개의 <스케줄 id, 거리 총합> 저장
+		HashMap<Long, Double> totalDistance = new HashMap<>();
+
+		// 스케줄, planOrder 순으로 조회되었다고 가정
+		// Math.round(pie*100)/100.0
+		for(int i=0; i<schedulePlanXYDto.size()-1; i++) {
+			if(schedulePlanXYDto.get(i).getScheduleId() == schedulePlanXYDto.get(i+1).getScheduleId()) {
+				double x1 = Double.parseDouble(schedulePlanXYDto.get(i).getX());
+				double y1 = Double.parseDouble(schedulePlanXYDto.get(i).getY());
+				double x2 = Double.parseDouble(schedulePlanXYDto.get(i+1).getX());
+				double y2 = Double.parseDouble(schedulePlanXYDto.get(i+1).getY());
+				long distance = (long) distance(x1,y1,x2,y2,"M");
+				System.out.println("scheduleId : " + schedulePlanXYDto.get(i).getScheduleId() + " | origin : " + schedulePlanXYDto.get(i+1).getPlanId() + " - " + schedulePlanXYDto.get(i).getPlanId());
+				System.out.println(schedulePlanXYDto.get(i).getPlanOrder() + " - " + schedulePlanXYDto.get(i+1).getPlanOrder() + "distance : " + distance);
+				totalDistance.put(schedulePlanXYDto.get(i).getScheduleId(), totalDistance.getOrDefault(schedulePlanXYDto.get(i).getScheduleId(), 0.0) + distance);
+			}
+
+		}
+
+		ArrayList<Long> sortedList = new ArrayList<>();
+
+		for (Map.Entry<Long, Double> entry : totalDistance.entrySet()) {
+			if(sortedList.isEmpty()) {
+				sortedList.add(entry.getKey());
+				continue;
+			}
+
+			int num =0;
+
+			while(entry.getValue() < totalDistance.get(sortedList.get(num)) && num < sortedList.size()) {
+				if(num > 10)
+					break;
+				num++;
+			}
+			if(num < 10) {
+				sortedList.add(num, entry.getKey());
+			}
+		}
+//		longDistanceSchedule.clear();
+		longDistanceScheduleDtoList.clear();
+		for (Long a : sortedList) {
+			Schedule s = scheduleIdList.get(a);
+			OtherUserScheduleDto ousd = OtherUserScheduleDto.builder()
+					.scheduleId(s.getId())
+					.totalDistance(totalDistance.get(s.getId())/(double)1000)
+					.startDate(s.getStartDate())
+					.endDate(s.getEndDate())
+					.views(s.getViews())
+					.build();
+
+			TravelType travelCode = travelTypeRepository.findBySchedule(s).orElseThrow(() -> new IllegalArgumentException("해당 스케줄의 TravelCode가 존재하지 않습니다."));
+			ousd.setTravelCode(travelCode.getTravelCode());
+			ousd.setTravelPeriod(ChronoUnit.DAYS.between(ousd.getStartDate(), ousd.getEndDate()));
+//			longDistanceSchedule.put(a, totalDistance.get(a));
+			longDistanceScheduleDtoList.add(ousd);
+			System.out.println("scheduleId : " + s.getId() + " : " + ousd.getScheduleId() + " distance : " + ousd.getTotalDistance());
+		}
+
+		log.info("최신화");
+	}
+
+	// 출처 - https://www.geodatasource.com/developers/java
+	private static double distance(double lat1, double lon1, double lat2, double lon2, String unit) {
+		if ((lat1 == lat2) && (lon1 == lon2)) {
+			return 0;
+		}
+		else {
+			double theta = lon1 - lon2;
+			double dist = Math.sin(Math.toRadians(lat1)) * Math.sin(Math.toRadians(lat2)) + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) * Math.cos(Math.toRadians(theta));
+			dist = Math.acos(dist);
+			dist = Math.toDegrees(dist);
+			dist = dist * 60 * 1.1515;
+			if (unit.equals("K")) {
+				dist = dist * 1.609344;
+			} else if (unit.equals("N")) {
+				dist = dist * 0.8684;
+			} else if (unit.equals("M")) {
+				dist = dist * 1609.344;
+			}
+			return (dist);
+		}
 	}
 }


### PR DESCRIPTION
메인페이지에서 다른 사람들의 스케줄을 필터로 조회하는 기능입니다. 가장 최신에 만들어진 1000개의 스케줄 중에서 특정 기준을 통해 100개를 뽑아 10개 단위로 0~9페이지까지 조회 가능합니다. 1시간 단위로 100개 리스트를 최신화 합니다.
1. 최신순 : 가장 최신에 만들어진 스케줄을 우선 조회하는 기능
2. 최다조회순 : 조회수(count)가 가장 많은 스케줄을 우선 조회하는 기능
3. 최장기간순 : 스케줄의 시작일과 종료일이 가장 긴 순으로 조회하는 기능
4. 최장거리순 : 스케줄 안에 존재하는 Plan의 Attraction간의 거리를 모두 더해 가장 긴 여행 거리를 가진 스케줄 순으로 조회하는 기능